### PR TITLE
Optionally configure  fs.inotify.max_user_watches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Watchman
 
 Installs [Watchman](https://facebook.github.io/watchman/).
+
+## Configuration
+
+If `node['watchman']['max_users_watches']` is present, the system will
+be configured to set `fs.inotify.max_user_watches` to its value.

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,8 @@ maintainer 'James Herdman'
 maintainer_email 'james@precisionnutrition.com'
 recipe 'watchman', 'Installs Watchman'
 license 'MIT'
-version '0.0.2'
+version '0.0.3'
+depends 'sysctl'
 
 # Because storing meta data in an executable format is brilliant... Ugh.. Chef :(
 if respond_to?(:source_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,3 +29,9 @@ bash 'extract watchman' do
 
   not_if { ::File.exists?(extract_path) }
 end
+
+include_recipe 'sysctl::default'
+sysctl_param 'fs.inotify.max_user_watches' do
+  value node['watchman']['max_user_watches']
+  only_if { node['watchman']['max_user_watches'] }
+end


### PR DESCRIPTION
added sysctl cookbook dependency

use sysctl to configure `fs.inotify.max_user_watches` if `node['watchman']['max_user_watches]` exists

bumped version

updated README
